### PR TITLE
Fix: Improve RGB to ANSI error handling in rendering

### DIFF
--- a/src/render/render.zig
+++ b/src/render/render.zig
@@ -34,7 +34,13 @@ pub const RgbColor = struct {
             &result,
             "{s};2;{d};{d};{d}",
             .{ prefix, self.r, self.g, self.b }
-        ) catch return "0";
+        ) catch {
+            if (is_bg) {
+                return NamedColor.default.toBg();
+            } else {
+                return NamedColor.default.toFg();
+            }
+        };
         
         return result[0..len.len];
     }


### PR DESCRIPTION
Previously, if the `std.fmt.bufPrint` call within `RgbColor.toAnsi` failed, it would return the string "0". This could lead to an ANSI style reset (SGR code 0), potentially causing unexpected rendering artifacts like black spots if the terminal's default background color was black and a different background was intended.

This change modifies the error handling to return the ANSI code for the default background color (from `NamedColor.default.toBg()`) if `is_bg` is true, or the default foreground color (from `NamedColor.default.toFg()`) if `is_bg` is false. This provides a safer and more predictable fallback in case of formatting errors during color conversion.